### PR TITLE
libcst 1.8.6 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/pyyaml-ft-feedstock/pr1/e4a1865

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/pyyaml-ft-feedstock/pr1/e4a1865

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler_version:  # [linux]
+  - 11.2.0  # [linux]
+rust_compiler_version:
+  - 1.89.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,11 +75,13 @@ test:
 
 about:
   home: https://github.com/Instagram/LibCST
+  summary: A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7 and 3.8 programs.
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7 and 3.8 programs.
-  doc_url: https://libcst.readthedocs.io/
+  description: |
+    A Concrete Syntax Tree (CST) parser and serializer library for Python
+  doc_url: https://libcst.readthedocs.io
   dev_url: https://github.com/Instagram/LibCST
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,8 @@ requirements:
     - pyyaml >=6.0.3  # [py>313]
     - typing-extensions  # [py<310]
 
+# E   ModuleNotFoundError: No module named 'hypothesmith' -> https://pypi.org/project/hypothesmith/
+{% set deselect_tests = " --deselect=test_fuzz.py" %}
 test:
   imports:
     - libcst
@@ -67,7 +69,7 @@ test:
     - libcst.tests
   commands:
     - pip check
-    - pytest --pyargs libcst.tests
+    - pytest --pyargs libcst.tests {{ deselect_tests }}
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
   host:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,6 @@ requirements:
     - pyyaml >=6.0.3  # [py>313]
     - typing-extensions  # [py<310]
 
-# E   ModuleNotFoundError: No module named 'hypothesmith' -> https://pypi.org/project/hypothesmith/
-{% set deselect_tests = " --deselect=test_fuzz.py" %}
 test:
   imports:
     - libcst
@@ -69,7 +67,9 @@ test:
     - libcst.tests
   commands:
     - pip check
-    - pytest --pyargs libcst.tests {{ deselect_tests }}
+    # E   ModuleNotFoundError: No module named 'hypothesmith' -> https://pypi.org/project/hypothesmith/
+    {% set ignore_tests = " --ignore=test_fuzz.py" %}
+    - pytest --pyargs libcst.tests {{ ignore_tests }}
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,8 +68,9 @@ test:
   commands:
     - pip check
     # E   ModuleNotFoundError: No module named 'hypothesmith' -> https://pypi.org/project/hypothesmith/
-    {% set ignore_tests = " --ignore=test_fuzz.py" %}
-    - pytest --pyargs libcst.tests {{ ignore_tests }}
+    - rm ${SP_DIR}/libcst/tests/test_fuzz.py  # [unix]
+    - del /f /q %SP_DIR%\libcst\tests\test_fuzz.py  # [win]
+    - pytest --pyargs libcst.tests 
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,9 @@ requirements:
     - pyyaml >=6.0.3  # [py>313]
     - typing-extensions  # [py<310]
 
+# E   AssertionError: self.assertTrue(fixtures.exists(), f"{fixtures} should exist")
+{% set deselect_tests = " --deselect=test_roundtrip.py::RoundTripTests::test_clean_roundtrip" %}
+{% set deselect_tests = deselect_tests + " --deselect=test_roundtrip.py::RoundTripTests::test_transform_roundtrip" %}
 test:
   imports:
     - libcst
@@ -70,7 +73,7 @@ test:
     # E   ModuleNotFoundError: No module named 'hypothesmith' -> https://pypi.org/project/hypothesmith/
     - rm ${SP_DIR}/libcst/tests/test_fuzz.py  # [unix]
     - del /f /q %SP_DIR%\libcst\tests\test_fuzz.py  # [win]
-    - pytest --pyargs libcst.tests 
+    - pytest --pyargs libcst.tests {{ deselect_tests }}
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,6 +72,7 @@ test:
   requires:
     - pip
     - pytest
+    - hypothesis
 
 about:
   home: https://github.com/Instagram/LibCST

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,40 +1,40 @@
 {% set name = "libcst" %}
-{% set version = "1.6.0" %}
+{% set version = "1.8.6" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e80ecdbe3fa43b3793cae8fa0b07a985bd9a693edbe6e9d076f5422ecadbf0db
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f729c37c9317126da9475bdd06a7208eb52fcbd180a6341648b45a56b4ba708b
 
 build:
   number: 0
-  skip: true  # [py<39]
-# Cargo is actively removed as the upstream package calls in a duplicate build, causing windows builds to fail.
   script:
     - rm %BUILD_PREFIX%\\.cargo.win\\config  # [win]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-  missing_dso_whitelist:  # [s390x]
-    - $RPATH/ld64.so.1    # [s390x]
-
+  skip: true  # [py<39]
 
 requirements:
-    build:
-    - {{ compiler('rust') }}
+  build:
+    - {{ stdlib('c') }}
+    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    host:
-    - python
+    - {{ compiler('rust') }}
+  host:
     - pip
+    - python
     - setuptools
     - setuptools-rust
     - setuptools_scm
     - wheel
-    - wheel
-    run:
+  run:
     - python
-    - pyyaml >=5.2
+    - pyyaml >=5.2  # [py<313]
+    - pyyaml-ft >=8.0.0  # [py==313]
+    - pyyaml >=6.0.3  # [py>313]
+    - typing-extensions  # [py<310]
 
 test:
   imports:
@@ -68,8 +68,10 @@ test:
     - libcst.tests
   commands:
     - pip check
+    - pytest --pyargs libcst.tests
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/Instagram/LibCST


### PR DESCRIPTION
libcst 1.8.6 

**Destination channel:** Defaults

### Links

- [PKG-11049]
- dev_url:        https://github.com/Instagram/LibCST/tree/v1.8.6
- conda_forge:    https://github.com/conda-forge/libcst-feedstock
- pypi:           https://pypi.org/project/libcst/1.8.6
- pypi inspector: https://inspector.pypi.io/project/libcst/1.8.6

### Explanation of changes:

- new version number


[PKG-11049]: https://anaconda.atlassian.net/browse/PKG-11049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ